### PR TITLE
Add rule_custom_name variable to PSC endpoints bare targets

### DIFF
--- a/modules/psc_forwarding_rule/main.tf
+++ b/modules/psc_forwarding_rule/main.tf
@@ -37,7 +37,7 @@ data "google_alloydb_instance" "alloydb_instance" {
 resource "google_compute_address" "psc_address" {
   for_each     = { for idx, config in var.psc_endpoints : idx => config if config.ip_address_literal != null }
   project      = each.value.endpoint_project_id
-  name         = "psc-compute-address-${each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? each.value.producer_cloudsql.instance_name : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? each.value.producer_alloydb.instance_name : "custom-${each.key}")}"
+  name         = "psc-compute-address-${each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? each.value.producer_cloudsql.instance_name : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? each.value.producer_alloydb.instance_name : "${each.value.rule_custom_name}-${each.key}")}"
   region       = each.value.region != null ? each.value.region : (each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? data.google_sql_database_instance.cloudsql_instance[each.key].region : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? data.google_alloydb_instance.alloydb_instance[each.key].location : split("/", each.value.target)[3]))
   address_type = "INTERNAL"
   subnetwork   = each.value.subnetwork_name
@@ -47,7 +47,7 @@ resource "google_compute_address" "psc_address" {
 resource "google_compute_forwarding_rule" "psc_forwarding_rule" {
   for_each                = { for idx, config in var.psc_endpoints : idx => config }
   project                 = each.value.endpoint_project_id
-  name                    = "psc-forwarding-rule-${each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? each.value.producer_cloudsql.instance_name : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? each.value.producer_alloydb.instance_name : "custom-${each.key}")}"
+  name                    = "psc-forwarding-rule-${each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? each.value.producer_cloudsql.instance_name : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? each.value.producer_alloydb.instance_name : "${each.value.rule_custom_name}-${each.key}")}"
   region                  = each.value.region != null ? each.value.region : (each.value.producer_cloudsql != null && each.value.producer_cloudsql.instance_name != null ? data.google_sql_database_instance.cloudsql_instance[each.key].region : (each.value.producer_alloydb != null && each.value.producer_alloydb.instance_name != null ? data.google_alloydb_instance.alloydb_instance[each.key].location : split("/", each.value.target)[3]))
   network                 = each.value.network_name
   subnetwork              = each.value.subnetwork_name

--- a/modules/psc_forwarding_rule/variables.tf
+++ b/modules/psc_forwarding_rule/variables.tf
@@ -57,6 +57,9 @@ variable "psc_endpoints" {
       cluster_id = optional(string)
     }), {})
 
+    # Rule custom name.
+    rule_custom_name = optional(string, "custom")
+
     # The target for the forwarding rule.
     target = optional(string)
   }))


### PR DESCRIPTION
This pull request updates the naming convention for Private Service Connect (PSC) resources in the `psc_forwarding_rule` Terraform module. The main change is to allow more flexible and descriptive custom names for PSC compute addresses and forwarding rules by introducing a new optional variable, `rule_custom_name`, which defaults to `"custom"`.

**Naming improvements for PSC resources:**

* Added a new optional variable `rule_custom_name` to the `psc_endpoints` variable definition, allowing users to specify a custom name base for PSC resources.
* Updated the `google_compute_address.psc_address` and `google_compute_forwarding_rule.psc_forwarding_rule` resources to use `rule_custom_name` (with the index as a suffix) instead of a hardcoded `"custom"` base when neither a CloudSQL nor AlloyDB instance name is present. [[1]](diffhunk://#diff-1d3b0d98f88c090553393a1484915d87daabb8738e65e17d1af1bbad376ac6eeL40-R40) [[2]](diffhunk://#diff-1d3b0d98f88c090553393a1484915d87daabb8738e65e17d1af1bbad376ac6eeL50-R50)