### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": false,
   "extends": [
     "config:recommended"
   ]


### PR DESCRIPTION
Disables the Renovate dependency dashboard by setting `dependencyDashboard: false` in renovate.json. 
This prevents the bot from continuously reopening the Dependency Dashboard issue every time it is closed manually.